### PR TITLE
fix(render): Fix casing on omit flags

### DIFF
--- a/Renderer/AddressRenderer.php
+++ b/Renderer/AddressRenderer.php
@@ -62,8 +62,8 @@ class AddressRenderer implements AddressRendererInterface
                 'country' => $address->getCountry(),
                 'countryName' => $this->countryNameProvider->getDisplayNameForCountry($address->getCountry(), $locale),
                 'format' => $format,
-                'omit_recipient' => (isset($options['omit_recipient'])) ? (bool) $options['omit_recipient'] : false,
-                'omit_country' => (isset($options['omit_country'])) ? (bool) $options['omit_country'] : false,
+                'omitRecipient' => (isset($options['omit_recipient'])) ? (bool) $options['omit_recipient'] : false,
+                'omitCountry' => (isset($options['omit_country'])) ? (bool) $options['omit_country'] : false,
             ]
         );
     }


### PR DESCRIPTION
All handlebar templates in the repo expect these to be passed through in camelCase, but the renderer is using snake_case. Have kept these as snake_case from a consumer perspective to maintain compatibility.

From the current setup:
![screen shot 2017-06-23 at 12 34 30](https://user-images.githubusercontent.com/3877652/27488771-246f8520-5830-11e7-980b-325314d98a2b.png)
![screen shot 2017-06-23 at 12 34 43](https://user-images.githubusercontent.com/3877652/27488772-2479424a-5830-11e7-9a1c-52529ce20498.png)
![screen shot 2017-06-23 at 12 34 57](https://user-images.githubusercontent.com/3877652/27488773-248b526e-5830-11e7-89a4-c209099cf98c.png)
![screen shot 2017-06-23 at 12 35 08](https://user-images.githubusercontent.com/3877652/27488774-249352de-5830-11e7-9a7d-843bf913175f.png)
