### PR TITLE
feat: remove handlebars escaping for non-html formats

### DIFF
--- a/Provider/IntlAddressHandlebarsTemplateProvider.php
+++ b/Provider/IntlAddressHandlebarsTemplateProvider.php
@@ -66,7 +66,8 @@ class IntlAddressHandlebarsTemplateProvider implements IntlAddressTemplateProvid
                 [
                     'flags' => Flags::FLAG_HANDLEBARSJS
                         | Flags::FLAG_ERROR_EXCEPTION
-                        | Flags::FLAG_THIS,
+                        | Flags::FLAG_THIS
+                        | (($format !== 'html') ? Flags::FLAG_NOESCAPE : 0),
                     'helpers' => $this->getHelperSetForFormat($format)->toArray()
                 ]
             );


### PR DESCRIPTION
Escaping of characters like apostrophes are not necessary when the render format is not HTML - UTF-8 characters should be fine raw.